### PR TITLE
Move executor image to IBM Cloud Container Registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,13 +114,13 @@ workflows:
                 - main
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - main
     jobs:
       - docker/hadolint:
           dockerfiles: default-executor/Dockerfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ workflows:
       - docker/publish:
           path: default-executor/
           image: instana/pipeline-feedback-orb-executor
+          context: icr-publish
           registry: icr.io
           docker-username: ICR_LOGIN
           docker-password: ICR_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,14 +114,13 @@ workflows:
                 - main
 
   nightly:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - main
-#                - use-ibm-cloud-container-registry
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - docker/hadolint:
           dockerfiles: default-executor/Dockerfile
@@ -135,7 +134,3 @@ workflows:
           docker-password: ICR_PASSWORD
           requires:
             - docker/hadolint
-          filters:
-            branches:
-              only:
-                - use-ibm-cloud-container-registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   pipeline-feedback: instana/pipeline-feedback@<<pipeline.parameters.dev-orb-version>>
-  docker: circleci/docker@1.5.0
+  docker: circleci/docker@2.0.1
   orb-tools: circleci/orb-tools@10.0.4
   bats: circleci/bats@1.0
   shellcheck: circleci/shellcheck@2.0
@@ -26,7 +26,7 @@ jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
   integration-test-1:
     docker:
-      - image: instana/pipeline-feedback-orb-executor:latest
+      - image: icr.io/instana/pipeline-feedback-orb-executor:latest
     steps:
       - checkout
       - pipeline-feedback/create_release:
@@ -114,13 +114,14 @@ workflows:
                 - main
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - main
+#                - use-ibm-cloud-container-registry
     jobs:
       - docker/hadolint:
           dockerfiles: default-executor/Dockerfile
@@ -128,6 +129,12 @@ workflows:
       - docker/publish:
           path: default-executor/
           image: instana/pipeline-feedback-orb-executor
-          use-remote-docker: true
+          registry: icr.io
+          docker-username: ICR_LOGIN
+          docker-password: ICR_PASSWORD
           requires:
             - docker/hadolint
+          filters:
+            branches:
+              only:
+                - use-ibm-cloud-container-registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,13 +114,13 @@ workflows:
                 - main
 
   nightly:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - docker/hadolint:
           dockerfiles: default-executor/Dockerfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ workflows:
       - docker/publish:
           path: default-executor/
           image: instana/pipeline-feedback-orb-executor
+          tag: latest,$CIRCLE_SHA1
           context: icr-publish
           registry: icr.io
           docker-username: ICR_LOGIN

--- a/src/examples/create_release.yml
+++ b/src/examples/create_release.yml
@@ -7,7 +7,7 @@ usage:
   version: "2.1"
 
   orbs:
-    pipeline-feedback: instana/pipeline-feedback@1.1.2
+    pipeline-feedback: instana/pipeline-feedback@1.3.1
 
   workflows:
     build_and_release_payment_service:
@@ -24,7 +24,7 @@ usage:
         - run: echo Build
     release_payment_service:
       docker:
-        - image: instana/pipeline-feedback-orb-executor:latest # Need to use a container with jq, curl and optionally envsubst
+        - image: icr.io/instana/pipeline-feedback-orb-executor:latest # Need to use a container with jq, curl and optionally envsubst
       steps:
         - pipeline-feedback/create_release: # Notify Instana that things are about to get interesting
             release_name: "My Awesome App release (CircleCI: ${CIRCLE_JOB}/${CIRCLE_BUILD_NUM})"

--- a/src/jobs/create_release.yml
+++ b/src/jobs/create_release.yml
@@ -7,7 +7,7 @@ docker:
 parameters:
   executor_image:
     type: string
-    default: instana/pipeline-feedback-orb-executor:latest
+    default: icr.io/instana/pipeline-feedback-orb-executor:latest
   endpoint:
     type: env_var_name
     default: INSTANA_ENDPOINT_URL


### PR DESCRIPTION
In order to provide security scanned images and Docker Hub does not provide such a capability at the moment, the docker image for the `pipeline-feedback-orb-executor` will be pushed to IBM Cloud Container Registry. See https://cloud.ibm.com/docs/Registry?topic=va-va_index&interface=ui for further details.