### PR TITLE
[semver:patch] Include ability to interpolate environments in the json scope

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST.md
@@ -1,34 +1,28 @@
 
 **SEMVER Update Type:**
-<<<<<<< HEAD
 
-=======
->>>>>>> [semver:skip] Initial commit.
 - [ ] Major
 - [ ] Minor
 - [ ] Patch
 
-## Description:
+## Description
 
 <!---
   Describe your changes in detail, preferably in an imperative mood,
   i.e., "add `commandA` to `jobB`"
  -->
 
-## Motivation:
+## Motivation
 
 <!---
   Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
  -->
 
  **Closes Issues:**
-<<<<<<< HEAD
 
-=======
->>>>>>> [semver:skip] Initial commit.
--  ISSUE URL
+- ISSUE URL
 
-## Checklist:
+## Checklist
 
 <!--
 	Thank you for contributing to CircleCI Orbs!
@@ -38,8 +32,4 @@
 
 - [ ] All new jobs, commands, executors, parameters have descriptions.
 - [ ] Usage Example version numbers have been updated.
-<<<<<<< HEAD
 - [ ] Changelog has been updated.
-=======
-- [ ] Changelog has been updated.
->>>>>>> [semver:skip] Initial commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [2.0.1] - 2022-10-30
+## [2.0.1] - 2022-12-20
 
 - Include the ability to parse environments in `release_scope` parameter
 ## [2.0.0] - 2022-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.0.1] - 2022-10-30
+
+- Include the ability to parse environments in `release_scope` parameter
 ## [2.0.0] - 2022-03-31
 
 - Use icr.io as registry for the default executor

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following example assumes that you set the `INSTANA_ENDPOINT_URL` and `INSTA
 version: 2.1
 
 orbs:
-  pipeline-feedback: instana/pipeline-feedback@2.0.0
+  pipeline-feedback: instana/pipeline-feedback@2.0.1
 
 workflows:
   create_release:
@@ -27,7 +27,7 @@ In case you want to customize which environment variables to use to look up the 
 version: 2.1
 
 orbs:
-  pipeline-feedback: instana/pipeline-feedback@2.0.0
+  pipeline-feedback: instana/pipeline-feedback@2.0.1
 
 workflows:
   create_release:

--- a/src/commands/create_release.yml
+++ b/src/commands/create_release.yml
@@ -18,8 +18,16 @@ parameters:
     description: The name of this release in Instana.
   release_scope:
     type: string
-    description: >
-      JSON-encoded scoping information for the release.
+    description: |
+      JSON-encoded scoping information for the release. 
+      It can now have environments nests in the string to be replaced like below:
+      ```json
+        {
+          "services": [
+            {"name": "${CIRCLE_PROJECT_REPONAME}.${ENV}"}
+          ]
+        }
+      ```
       If not provided, the release will be marked as global to your tenant unit.
     default: "{}"
 

--- a/src/commands/create_release.yml
+++ b/src/commands/create_release.yml
@@ -20,7 +20,7 @@ parameters:
     type: string
     description: |
       JSON-encoded scoping information for the release. 
-      It can now have environments nests in the string to be replaced like below:
+      The usage of environment variables is supported. Example:
       ```json
         {
           "services": [

--- a/src/examples/create_release.yml
+++ b/src/examples/create_release.yml
@@ -7,7 +7,7 @@ usage:
   version: "2.1"
 
   orbs:
-    pipeline-feedback: instana/pipeline-feedback@2.0.0
+    pipeline-feedback: instana/pipeline-feedback@2.0.1
 
   workflows:
     build_and_release_payment_service:
@@ -35,6 +35,10 @@ usage:
                 ],
                 "services": [
                   { "name": "Cool service #1" },
+                  { "name": "${CIRCLE_PROJECT_REPONAME}" },
+                  { "name": "${CIRCLE_PROJECT_REPONAME}.production" },
+                  { "name": "${CIRCLE_PROJECT_REPONAME}.staging" },
+                  { "name": "${CIRCLE_PROJECT_REPONAME}.dev" },
                   {
                     "name": "Cool service #2",
                     "scopedTo": {

--- a/src/scripts/create_release.sh
+++ b/src/scripts/create_release.sh
@@ -36,7 +36,9 @@ function create_release() {
         INSTANA_RELEASE_SCOPE='{}'
     fi
 
-    echo "${INSTANA_RELEASE_SCOPE}" > scope.json
+    JSON_STRING_FULL=$(echo $INSTANA_RELEASE_SCOPE | jq | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/`/\\`/g' )
+    INTERPOLATED_JSON=$(eval echo $JSON_STRING_FULL)
+    echo "${INTERPOLATED_JSON}" > scope.json
 
     if ! OUTPUT=$(jq empty scope.json 2>&1); then
         echo "Scope JSON is valid: ${OUTPUT}"

--- a/src/scripts/create_release.sh
+++ b/src/scripts/create_release.sh
@@ -23,22 +23,23 @@ function create_release() {
         exit 1
     fi
 
-    if which envsubst; then
-        release_name=$(echo "${INSTANA_RELEASE_NAME}" | envsubst)
-    else
-        echo 'The envsubst command is not available, skipping the interpolation of environment variables in the release name'
-        release_name="${INSTANA_RELEASE_NAME}"
-    fi
-
-    echo "Creating release '${release_name}'"
-
     if [ -z "${INSTANA_RELEASE_SCOPE}" ]; then
         INSTANA_RELEASE_SCOPE='{}'
     fi
 
+    echo "Creating release '${release_name}'"
     JSON_STRING_FULL=$(echo $INSTANA_RELEASE_SCOPE | jq -c | jq -R)
-    INTERPOLATED_JSON=$(eval echo $JSON_STRING_FULL)
-    echo "${INTERPOLATED_JSON}" > scope.json
+
+    if which envsubst; then
+        release_name=$(echo "${INSTANA_RELEASE_NAME}" | envsubst)
+        INTERPOLATED_JSON=$(echo $JSON_STRING_FULL | envsubst)
+    else
+        echo 'The envsubst command is not available, skipping the interpolation of environment variables in the release name and release scope'
+        release_name="${INSTANA_RELEASE_NAME}"
+        INTERPOLATED_JSON=$(echo $JSON_STRING_FULL)
+    fi
+
+    echo "${INTERPOLATED_JSON}" >scope.json
 
     if ! OUTPUT=$(jq empty scope.json 2>&1); then
         echo "Scope JSON is valid: ${OUTPUT}"

--- a/src/scripts/create_release.sh
+++ b/src/scripts/create_release.sh
@@ -36,7 +36,7 @@ function create_release() {
         INSTANA_RELEASE_SCOPE='{}'
     fi
 
-    JSON_STRING_FULL=$(echo $INSTANA_RELEASE_SCOPE | jq | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/`/\\`/g' )
+    JSON_STRING_FULL=$(echo $INSTANA_RELEASE_SCOPE | jq -c | jq -R)
     INTERPOLATED_JSON=$(eval echo $JSON_STRING_FULL)
     echo "${INTERPOLATED_JSON}" > scope.json
 

--- a/src/tests/create_release.bats
+++ b/src/tests/create_release.bats
@@ -46,3 +46,16 @@ export INSTANA_RELEASE_NAME="BATS 2 Test CircleCI release"
 
     [ "$status" -eq 1 ]
 }
+
+@test '5: Create Service-scoped Release using environments' {
+    export LOCAL_TEST5_SERVICE_NAME=testing
+    export INSTANA_RELEASE_SCOPE='
+    {
+        "services": [{
+            "name": "${LOCAL_TEST5_SERVICE_NAME}"
+        }]
+    }'
+
+    run ./src/scripts/create_release.sh
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Include the ability to interpolate environments in the JSON string on the `release_scope` parameters on the command `create_release`

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  ISSUE URL #12 

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.

### Pieces of evidence of the code are working

![image](https://user-images.githubusercontent.com/10054367/197061278-b229d999-746c-4ac3-8e77-12781d38e990.png)
